### PR TITLE
Fix typo in dictionary attribute.

### DIFF
--- a/dvh/dicom_to_sql.py
+++ b/dvh/dicom_to_sql.py
@@ -200,7 +200,7 @@ def get_file_paths(start_path):
                 file_paths[uid] = {'rtplan': {'file_path': [], 'timestamp': [], 'latest_file': []},
                                    'rtstruct': {'file_path': [], 'timestamp': [], 'latest_file': []},
                                    'rtdose': {'file_path': [], 'timestamp': [], 'latest_file': []},
-                                   'other': {'file_path': [], 'time_stamp': []}}
+                                   'other': {'file_path': [], 'timestamp': []}}
 
             if file_type not in file_types:
                 file_type = 'other'


### PR DESCRIPTION
Fix a typo in the timestamp attribute in use for DICOM imports. Without this, any valid DICOM file found in the import path that matches the `other` category causes the program to crash when the timestamp is attempted to be appended to the timestamp list.