### PR TITLE
0.4.4dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change log of DVH Analytics
 
+### 0.4.4 (TBD)
+* Shapely speedups enabled, if available
+    * Shapely has calcs available in C, as opposed to C++
+* centroid, dist_to_ptv_centroids, dth (distance to target histogram), spread_x, spread_y, spread_z, cross_section_max, 
+cross_section_median, columns added to DVHs
+    * These columns can be added by clicking Create Tables from Settings view, if running from source
+    * Running from Docker or pip install shouldn't need to do this manually
+* dist_to_ptv_centroids and dth must be calculated from Admin view after proper ROI name mapping
+* dth_string calculated with Calc PTV Dist in Admin view
+    * the string stored is csv representing a histogram with 0.1mm bins
+* centroid, spread, and cross-sections also calculated at time of import
+    * calc in Admin view only required for data imported prior to 0.4.4 install
+* Admin view now specifies Post-Import calculations via dropdown
+    * Added choice "Default Post-Import" to run through all calcs not done at time of DICOM import
+
 ### 0.4.3 (2018.08.04)
 * IMPORT_LATEST_ONLY removed from options.py in lieu of a simple checkbox in the admin view.
 * Settings view now has functionality to edit parameters in options.py. These edits are stored 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ cross_section_median, columns added to DVHs
     * calc in Admin view only required for data imported prior to 0.4.4 install
 * Admin view now specifies Post-Import calculations via dropdown
     * Added choice "Default Post-Import" to run through all calcs not done at time of DICOM import
+* typo in keyword for parameter in dicom_to_sql (import_latest_plan_only changes to import_latest_only)
 
 ### 0.4.3 (2018.08.04)
 * IMPORT_LATEST_ONLY removed from options.py in lieu of a simple checkbox in the admin view.

--- a/dvh/analysis_tools.py
+++ b/dvh/analysis_tools.py
@@ -56,6 +56,8 @@ class DVH:
                 self.bin_count = current_size
         self.dvh = np.zeros([self.bin_count, self.count])
 
+        self.dth = []
+
         # Get needed values not in DVHs table
         for i in range(self.count):
             # Get Rx Doses
@@ -71,6 +73,12 @@ class DVH:
                 current_dvh = np.divide(current_dvh, current_dvh_max)
             zero_fill = np.zeros(self.bin_count - len(current_dvh))
             self.dvh[:, i] = np.concatenate((current_dvh, zero_fill))
+
+            # Process dth_string to numpy array
+            try:
+                self.dth.append(np.array(self.dth_string[i].split(','), dtype='|S4').astype(np.float))
+            except:
+                self.dth.append(np.array([0]))
 
     def get_percentile_dvh(self, percentile):
         """

--- a/dvh/dicom_to_sql.py
+++ b/dvh/dicom_to_sql.py
@@ -24,7 +24,7 @@ SCRIPT_DIR = os.path.dirname(__file__)
 
 
 def dicom_to_sql(start_path=None, force_update=False, move_files=True,
-                 update_dicom_catalogue_table=True, import_latest_plan_only=True):
+                 update_dicom_catalogue_table=True, import_latest_only=True):
 
     start_time = datetime.now()
     print(str(start_time), 'Beginning import', sep=' ')
@@ -65,7 +65,7 @@ def dicom_to_sql(start_path=None, force_update=False, move_files=True,
         plan_file = file_paths[uid]['rtplan']['latest_file']
         struct_file = file_paths[uid]['rtstruct']['latest_file']
         dose_file = file_paths[uid]['rtdose']['latest_file']
-        if import_latest_plan_only:
+        if import_latest_only:
             print("plan file: %s" % plan_file)
         else:
             for f in file_paths[uid]['rtplan']['file_path']:
@@ -88,7 +88,7 @@ def dicom_to_sql(start_path=None, force_update=False, move_files=True,
             continue
 
         if plan_file and struct_file and dose_file:
-            if import_latest_plan_only:
+            if import_latest_only:
                 plan = PlanRow(plan_file, struct_file, dose_file)
                 sqlcnx.insert_plan(plan)
             else:
@@ -104,7 +104,7 @@ def dicom_to_sql(start_path=None, force_update=False, move_files=True,
 
         if plan_file:
             if not hasattr(dicom.read_file(plan_file), 'BrachyTreatmentType'):
-                if import_latest_plan_only:
+                if import_latest_only:
                     beams = BeamTable(plan_file)
                     sqlcnx.insert_beams(beams)
                 else:
@@ -115,7 +115,7 @@ def dicom_to_sql(start_path=None, force_update=False, move_files=True,
             setattr(dvhs, 'ptv_number', rank_ptvs_by_D95(dvhs))
             sqlcnx.insert_dvhs(dvhs)
         if plan_file and struct_file:
-            if import_latest_plan_only:
+            if import_latest_only:
                 rxs = RxTable(plan_file, struct_file)
                 sqlcnx.insert_rxs(rxs)
             else:
@@ -153,7 +153,7 @@ def dicom_to_sql(start_path=None, force_update=False, move_files=True,
             dose_file = os.path.basename(dose_file)
 
         if update_dicom_catalogue_table:
-            if not import_latest_plan_only:
+            if not import_latest_only:
                 plan_file = ', '.join([os.path.basename(fp) for fp in file_paths[uid]['rtplan']['file_path']])
             update_dicom_catalogue(mrn, uid, new_folder, plan_file, struct_file, dose_file)
 

--- a/dvh/main.py
+++ b/dvh/main.py
@@ -198,14 +198,20 @@ range_categories = {'Age': {'var_name': 'age', 'table': 'Plans', 'units': '', 's
                     'ROI Max Dose': {'var_name': 'max_dose', 'table': 'DVHs', 'units': 'Gy', 'source': source},
                     'ROI Volume': {'var_name': 'volume', 'table': 'DVHs', 'units': 'cc', 'source': source},
                     'ROI Surface Area': {'var_name': 'surface_area', 'table': 'DVHs', 'units': 'cm^2', 'source': source},
+                    'ROI Spread X': {'var_name': 'spread_x', 'table': 'DVHs', 'units': 'cm', 'source': source},
+                    'ROI Spread Y': {'var_name': 'spread_y', 'table': 'DVHs', 'units': 'cm', 'source': source},
+                    'ROI Spread Z': {'var_name': 'spread_z', 'table': 'DVHs', 'units': 'cm', 'source': source},
                     'PTV Distance (Min)': {'var_name': 'dist_to_ptv_min', 'table': 'DVHs', 'units': 'cm', 'source': source},
                     'PTV Distance (Mean)': {'var_name': 'dist_to_ptv_mean', 'table': 'DVHs', 'units': 'cm', 'source': source},
                     'PTV Distance (Median)': {'var_name': 'dist_to_ptv_median', 'table': 'DVHs', 'units': 'cm', 'source': source},
                     'PTV Distance (Max)': {'var_name': 'dist_to_ptv_max', 'table': 'DVHs', 'units': 'cm', 'source': source},
+                    'PTV Distance (Centroids)': {'var_name': 'dist_to_ptv_centroids', 'table': 'DVHs', 'units': 'cm', 'source': source},
                     'PTV Overlap': {'var_name': 'ptv_overlap', 'table': 'DVHs', 'units': 'cc', 'source': source},
                     'Scan Spots': {'var_name': 'scan_spot_count', 'table': 'Beams', 'units': '', 'source': source_beams},
                     'Beam MU per deg': {'var_name': 'beam_mu_per_deg', 'table': 'Beams', 'units': '', 'source': source_beams},
-                    'Beam MU per control point': {'var_name': 'beam_mu_per_cp', 'table': 'Beams', 'units': '', 'source': source_beams}}
+                    'Beam MU per control point': {'var_name': 'beam_mu_per_cp', 'table': 'Beams', 'units': '', 'source': source_beams},
+                    'ROI Cross-Section Max': {'var_name': 'cross_section_max', 'table': 'DVHs', 'units': 'cm^2', 'source': source},
+                    'ROI Cross-Section Median': {'var_name': 'cross_section_median', 'table': 'DVHs', 'units': 'cm^2', 'source': source}}
 
 # correlation variable names
 correlation_variables, correlation_names = [], []
@@ -1008,7 +1014,13 @@ def update_dvh_data(dvh):
         dvh.dist_to_ptv_median.extend(calc_stats(dvh_group_1.dist_to_ptv_median))
         dvh.dist_to_ptv_mean.extend(calc_stats(dvh_group_1.dist_to_ptv_mean))
         dvh.dist_to_ptv_max.extend(calc_stats(dvh_group_1.dist_to_ptv_max))
+        dvh.dist_to_ptv_centroids.extend(calc_stats(dvh_group_1.dist_to_ptv_centroids))
         dvh.ptv_overlap.extend(calc_stats(dvh_group_1.ptv_overlap))
+        dvh.cross_section_max.extend(calc_stats(dvh_group_1.cross_section_max))
+        dvh.cross_section_median.extend(calc_stats(dvh_group_1.cross_section_median))
+        dvh.spread_x.extend(calc_stats(dvh_group_1.spread_x))
+        dvh.spread_y.extend(calc_stats(dvh_group_1.spread_y))
+        dvh.spread_z.extend(calc_stats(dvh_group_1.spread_z))
     if group_2_constraint_count > 0:
         dvh.rx_dose.extend(calc_stats(dvh_group_2.rx_dose))
         dvh.volume.extend(calc_stats(dvh_group_2.volume))
@@ -1020,7 +1032,13 @@ def update_dvh_data(dvh):
         dvh.dist_to_ptv_median.extend(calc_stats(dvh_group_2.dist_to_ptv_median))
         dvh.dist_to_ptv_mean.extend(calc_stats(dvh_group_2.dist_to_ptv_mean))
         dvh.dist_to_ptv_max.extend(calc_stats(dvh_group_2.dist_to_ptv_max))
+        dvh.dist_to_ptv_centroids.extend(calc_stats(dvh_group_2.dist_to_ptv_centroids))
         dvh.ptv_overlap.extend(calc_stats(dvh_group_2.ptv_overlap))
+        dvh.cross_section_max.extend(calc_stats(dvh_group_2.cross_section_max))
+        dvh.cross_section_median.extend(calc_stats(dvh_group_2.cross_section_median))
+        dvh.spread_x.extend(calc_stats(dvh_group_2.spread_x))
+        dvh.spread_y.extend(calc_stats(dvh_group_2.spread_y))
+        dvh.spread_z.extend(calc_stats(dvh_group_2.spread_z))
 
     # Adjust dvh object for review dvh
     dvh.dvh = np.insert(dvh.dvh, 0, 0, 1)
@@ -1041,7 +1059,13 @@ def update_dvh_data(dvh):
     dvh.dist_to_ptv_mean.insert(0, 'N/A')
     dvh.dist_to_ptv_median.insert(0, 'N/A')
     dvh.dist_to_ptv_max.insert(0, 'N/A')
+    dvh.dist_to_ptv_centroids.insert(0, 'N/A')
     dvh.ptv_overlap.insert(0, 'N/A')
+    dvh.cross_section_max.insert(0, 'N/A')
+    dvh.cross_section_median.insert(0, 'N/A')
+    dvh.spread_x.insert(0, 'N/A')
+    dvh.spread_y.insert(0, 'N/A')
+    dvh.spread_z.insert(0, 'N/A')
     line_colors.insert(0, options.REVIEW_DVH_COLOR)
     x_data.insert(0, [0])
     y_data.insert(0, [0])
@@ -1069,7 +1093,13 @@ def update_dvh_data(dvh):
                    'dist_to_ptv_mean': dvh.dist_to_ptv_mean,
                    'dist_to_ptv_median': dvh.dist_to_ptv_median,
                    'dist_to_ptv_max': dvh.dist_to_ptv_max,
+                   'dist_to_ptv_centroids': dvh.dist_to_ptv_centroids,
                    'ptv_overlap': dvh.ptv_overlap,
+                   'cross_section_max': dvh.cross_section_max,
+                   'cross_section_median': dvh.cross_section_median,
+                   'spread_x': dvh.spread_x,
+                   'spread_y': dvh.spread_y,
+                   'spread_z': dvh.spread_z,
                    'x': x_data,
                    'y': y_data,
                    'color': line_colors,

--- a/dvh/mlc_analyzer.py
+++ b/dvh/mlc_analyzer.py
@@ -11,6 +11,12 @@ import numpy as np
 from shapely.geometry import Polygon
 from utilities import flatten_list_of_lists as flatten
 from options import MAX_FIELD_SIZE_X, MAX_FIELD_SIZE_Y, COMPLEXITY_SCORE_X_WEIGHT, COMPLEXITY_SCORE_Y_WEIGHT
+from shapely import speedups
+
+
+# Enable shapely calculations using C, as opposed to the C++ default
+if speedups.available:
+    speedups.enable()
 
 
 class Plan:

--- a/dvh/preferences/create_tables.sql
+++ b/dvh/preferences/create_tables.sql
@@ -3,3 +3,12 @@ CREATE TABLE IF NOT EXISTS DVHs (mrn text, study_instance_uid text, institutiona
 CREATE TABLE IF NOT EXISTS Beams (mrn text, study_instance_uid text, beam_number int, beam_name varchar(30), fx_grp_number smallint, fx_count int, fx_grp_beam_count smallint, beam_dose real, beam_mu real, radiation_type varchar(30), beam_energy_min real, beam_energy_max real, beam_type varchar(30), control_point_count int, gantry_start real, gantry_end real, gantry_rot_dir varchar(5), gantry_range real, gantry_min real, gantry_max real, collimator_start real, collimator_end real, collimator_rot_dir varchar(5), collimator_range real, collimator_min real, collimator_max real, couch_start real, couch_end real, couch_rot_dir varchar(5), couch_range real, couch_min real, couch_max real, beam_dose_pt varchar(35), isocenter varchar(35), ssd real, treatment_machine varchar(30), scan_mode varchar(30), scan_spot_count real, beam_mu_per_deg real, beam_mu_per_cp real, import_time_stamp timestamp);
 CREATE TABLE IF NOT EXISTS Rxs (mrn text, study_instance_uid text, plan_name varchar(50), fx_grp_name varchar(30), fx_grp_number smallint, fx_grp_count smallint, fx_dose real, fxs smallint, rx_dose real, rx_percent real, normalization_method varchar(30), normalization_object varchar(30), import_time_stamp timestamp);
 CREATE TABLE IF NOT EXISTS DICOM_Files (mrn text, study_instance_uid text, folder_path text, plan_file text, structure_file text, dose_file text, import_time_stamp timestamp);
+-- The following columns have been added as of DVH Analytics 0.4.4
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS centroid varchar(35);
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS dist_to_ptv_centroids real;
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS dth_string text;
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS spread_x real;
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS spread_y real;
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS spread_z real;
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS cross_section_max real;
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS cross_section_median real;

--- a/dvh/sql_connector.py
+++ b/dvh/sql_connector.py
@@ -37,7 +37,8 @@ class DVH_SQL:
     def execute_file(self, sql_file_name):
 
         for line in open(sql_file_name):
-            self.cursor.execute(line)
+            if not line.startswith('--'):  # ignore commented lines
+                self.cursor.execute(line)
         self.cnx.commit()
 
     def check_table_exists(self, table_name):
@@ -92,10 +93,17 @@ class DVH_SQL:
         return bool(results)
 
     def insert_dvhs(self, dvh_table):
+        print('Inserting dvh_table')
         file_path = 'insert_values_DVHs.sql'
 
         if os.path.isfile(file_path):
             os.remove(file_path)
+
+        col_names = ['mrn', 'study_instance_uid', 'institutional_roi', 'physician_roi', 'roi_name', 'roi_type',
+                     'volume', 'min_dose', 'mean_dose', 'max_dose', 'dvh_string', 'roi_coord_string',
+                     'dist_to_ptv_min', 'dist_to_ptv_mean', 'dist_to_ptv_median', 'dist_to_ptv_max', 'surface_area',
+                     'ptv_overlap', 'centroid', 'spread_x', 'spread_y', 'spread_z', 'cross_section_max',
+                     'cross_section_median', 'import_time_stamp']
 
         # Import each ROI from ROI_PyTable, append to output text file
         if max(dvh_table.ptv_number) > 1:
@@ -105,33 +113,38 @@ class DVH_SQL:
         for x in range(dvh_table.count):
             if multi_ptv and dvh_table.ptv_number[x] > 0:
                 dvh_table.roi_type[x] = 'PTV' + str(dvh_table.ptv_number[x])
-            sql_input = [str(dvh_table.mrn[x]),
-                         str(dvh_table.study_instance_uid[x]),
-                         dvh_table.institutional_roi[x],
-                         dvh_table.physician_roi[x],
-                         dvh_table.roi_name[x].replace("'", "`"),
-                         dvh_table.roi_type[x],
-                         str(round(dvh_table.volume[x], 3)),
-                         str(round(dvh_table.min_dose[x], 2)),
-                         str(round(dvh_table.mean_dose[x], 2)),
-                         str(round(dvh_table.max_dose[x], 2)),
-                         dvh_table.dvh_str[x],
-                         dvh_table.roi_coord[x],
-                         '(NULL)',
-                         '(NULL)',
-                         '(NULL)',
-                         '(NULL)',
-                         str(round(dvh_table.surface_area[x], 2)),
-                         '(NULL)',
-                         'NOW()']
-            sql_input = '\',\''.join(sql_input)
-            sql_input += '\');'
-            sql_input = sql_input.replace("'(NULL)'", "(NULL)")
-            prepend = 'INSERT INTO DVHs VALUES (\''
-            sql_input = prepend + str(sql_input)
-            sql_input += '\n'
+
+            values = [str(dvh_table.mrn[x]),
+                      str(dvh_table.study_instance_uid[x]),
+                      dvh_table.institutional_roi[x],
+                      dvh_table.physician_roi[x],
+                      dvh_table.roi_name[x].replace("'", "`"),
+                      dvh_table.roi_type[x],
+                      str(round(dvh_table.volume[x], 3)),
+                      str(round(dvh_table.min_dose[x], 2)),
+                      str(round(dvh_table.mean_dose[x], 2)),
+                      str(round(dvh_table.max_dose[x], 2)),
+                      dvh_table.dvh_str[x],
+                      dvh_table.roi_coord[x],
+                      '(NULL)',
+                      '(NULL)',
+                      '(NULL)',
+                      '(NULL)',
+                      str(round(dvh_table.surface_area[x], 2)),
+                      '(NULL)',
+                      dvh_table.centroid[x],
+                      dvh_table.spread_x[x],
+                      dvh_table.spread_y[x],
+                      dvh_table.spread_z[x],
+                      str(round(dvh_table.cross_section_max[x], 3)),
+                      str(round(dvh_table.cross_section_median[x], 3)),
+                      'NOW()']
+
+            cmd = "INSERT INTO DVHs (%s) VALUES ('%s');\n" % \
+                  (','.join(col_names), "','".join(values).replace("'(NULL)'", "(NULL)"))
+
             with open(file_path, "a") as text_file:
-                text_file.write(sql_input)
+                text_file.write(cmd)
 
         self.execute_file(file_path)
         os.remove(file_path)
@@ -146,38 +159,41 @@ class DVH_SQL:
             os.remove(file_path)
 
         # Import each ROI from ROI_PyTable, append to output text file
-        sql_input = [str(plan.mrn),
-                     plan.study_instance_uid,
-                     str(plan.birth_date),
-                     str(plan.age),
-                     plan.patient_sex,
-                     str(plan.sim_study_date),
-                     plan.physician,
-                     plan.tx_site,
-                     str(plan.rx_dose),
-                     str(plan.fxs),
-                     plan.patient_orientation,
-                     str(plan.plan_time_stamp),
-                     str(plan.struct_time_stamp),
-                     str(plan.dose_time_stamp),
-                     plan.tps_manufacturer,
-                     plan.tps_software_name,
-                     str(plan.tps_software_version),
-                     plan.tx_modality,
-                     str(plan.tx_time),
-                     str(plan.total_mu),
-                     plan.dose_grid_resolution,
-                     plan.heterogeneity_correction,
-                     'false',
-                     'NOW()']
-        sql_input = '\',\''.join(sql_input)
-        sql_input += '\');'
-        sql_input = sql_input.replace("'(NULL)'", "(NULL)")
-        prepend = 'INSERT INTO Plans VALUES (\''
-        sql_input = prepend + str(sql_input)
-        sql_input += '\n'
+        col_names = ['mrn', 'study_instance_uid', 'birth_date', 'age', 'patient_sex', 'sim_study_date', 'physician',
+                     'tx_site', 'rx_dose', 'fxs', 'patient_orientation', 'plan_time_stamp', 'struct_time_stamp',
+                     'dose_time_stamp', 'tps_manufacturer', 'tps_software_name', 'tps_software_version', 'tx_modality',
+                     'tx_time', 'total_mu', 'dose_grid_res', 'heterogeneity_correction', 'baseline',
+                     'import_time_stamp']
+        values = [str(plan.mrn),
+                  plan.study_instance_uid,
+                  str(plan.birth_date),
+                  str(plan.age),
+                  plan.patient_sex,
+                  str(plan.sim_study_date),
+                  plan.physician,
+                  plan.tx_site,
+                  str(plan.rx_dose),
+                  str(plan.fxs),
+                  plan.patient_orientation,
+                  str(plan.plan_time_stamp),
+                  str(plan.struct_time_stamp),
+                  str(plan.dose_time_stamp),
+                  plan.tps_manufacturer,
+                  plan.tps_software_name,
+                  str(plan.tps_software_version),
+                  plan.tx_modality,
+                  str(plan.tx_time),
+                  str(plan.total_mu),
+                  plan.dose_grid_resolution,
+                  plan.heterogeneity_correction,
+                  'false',
+                  'NOW()']
+
+        cmd = "INSERT INTO Plans (%s) VALUES ('%s');\n" % \
+              (','.join(col_names), "','".join(values).replace("'(NULL)'", "(NULL)"))
+
         with open(file_path, "a") as text_file:
-            text_file.write(sql_input)
+            text_file.write(cmd)
 
         self.execute_file(file_path)
         os.remove(file_path)
@@ -192,57 +208,62 @@ class DVH_SQL:
         if os.path.isfile(file_path):
             os.remove(file_path)
 
+        col_names = ['mrn', 'study_instance_uid', 'beam_number', 'beam_name', 'fx_grp_number', 'fx_count',
+                     'fx_grp_beam_count', 'beam_dose', 'beam_mu', 'radiation_type', 'beam_energy_min',
+                     'beam_energy_max', 'beam_type', 'control_point_count', 'gantry_start', 'gantry_end',
+                     'gantry_rot_dir', 'gantry_range', 'gantry_min', 'gantry_max', 'collimator_start', 'collimator_end',
+                     'collimator_rot_dir', 'collimator_range', 'collimator_min', 'collimator_max', 'couch_start',
+                     'couch_end', 'couch_rot_dir', 'couch_range', 'couch_min', 'couch_max', 'beam_dose_pt', 'isocenter',
+                     'ssd', 'treatment_machine', 'scan_mode', 'scan_spot_count', 'beam_mu_per_deg', 'beam_mu_per_cp',
+                     'import_time_stamp']
+
         # Import each ROI from ROI_PyTable, append to output text file
         for x in range(beams.count):
 
             if beams.beam_mu[x] > 0:
-                sql_input = [str(beams.mrn[x]),
-                             str(beams.study_instance_uid[x]),
-                             str(beams.beam_number[x]),
-                             beams.beam_name[x].replace("'", "`"),
-                             str(beams.fx_group[x]),
-                             str(beams.fxs[x]),
-                             str(beams.fx_grp_beam_count[x]),
-                             str(round(beams.beam_dose[x], 3)),
-                             str(beams.beam_mu[x]),
-                             beams.radiation_type[x],
-                             str(round(beams.beam_energy_min[x], 2)),
-                             str(round(beams.beam_energy_max[x], 2)),
-                             beams.beam_type[x],
-                             str(beams.control_point_count[x]),
-                             str(beams.gantry_start[x]),
-                             str(beams.gantry_end[x]),
-                             beams.gantry_rot_dir[x],
-                             str(beams.gantry_range[x]),
-                             str(beams.gantry_min[x]),
-                             str(beams.gantry_max[x]),
-                             str(beams.collimator_start[x]),
-                             str(beams.collimator_end[x]),
-                             beams.collimator_rot_dir[x],
-                             str(beams.collimator_range[x]),
-                             str(beams.collimator_min[x]),
-                             str(beams.collimator_max[x]),
-                             str(beams.couch_start[x]),
-                             str(beams.couch_end[x]),
-                             beams.couch_rot_dir[x],
-                             str(beams.couch_range[x]),
-                             str(beams.couch_min[x]),
-                             str(beams.couch_max[x]),
-                             beams.beam_dose_pt[x],
-                             beams.isocenter[x],
-                             str(beams.ssd[x]),
-                             beams.treatment_machine[x],
-                             beams.scan_mode[x],
-                             str(beams.scan_spot_count[x]),
-                             str(beams.beam_mu_per_deg[x]),
-                             str(beams.beam_mu_per_cp[x]),
-                             'NOW()']
-                sql_input = '\',\''.join(sql_input)
-                sql_input += '\');'
-                sql_input = sql_input.replace("'(NULL)'", "(NULL)")
-                prepend = 'INSERT INTO Beams VALUES (\''
-                sql_input = prepend + str(sql_input)
-                sql_input += '\n'
+                values = [str(beams.mrn[x]),
+                          str(beams.study_instance_uid[x]),
+                          str(beams.beam_number[x]),
+                          beams.beam_name[x].replace("'", "`"),
+                          str(beams.fx_group[x]),
+                          str(beams.fxs[x]),
+                          str(beams.fx_grp_beam_count[x]),
+                          str(round(beams.beam_dose[x], 3)),
+                          str(beams.beam_mu[x]),
+                          beams.radiation_type[x],
+                          str(round(beams.beam_energy_min[x], 2)),
+                          str(round(beams.beam_energy_max[x], 2)),
+                          beams.beam_type[x],
+                          str(beams.control_point_count[x]),
+                          str(beams.gantry_start[x]),
+                          str(beams.gantry_end[x]),
+                          beams.gantry_rot_dir[x],
+                          str(beams.gantry_range[x]),
+                          str(beams.gantry_min[x]),
+                          str(beams.gantry_max[x]),
+                          str(beams.collimator_start[x]),
+                          str(beams.collimator_end[x]),
+                          beams.collimator_rot_dir[x],
+                          str(beams.collimator_range[x]),
+                          str(beams.collimator_min[x]),
+                          str(beams.collimator_max[x]),
+                          str(beams.couch_start[x]),
+                          str(beams.couch_end[x]),
+                          beams.couch_rot_dir[x],
+                          str(beams.couch_range[x]),
+                          str(beams.couch_min[x]),
+                          str(beams.couch_max[x]),
+                          beams.beam_dose_pt[x],
+                          beams.isocenter[x],
+                          str(beams.ssd[x]),
+                          beams.treatment_machine[x],
+                          beams.scan_mode[x],
+                          str(beams.scan_spot_count[x]),
+                          str(beams.beam_mu_per_deg[x]),
+                          str(beams.beam_mu_per_cp[x]),
+                          'NOW()']
+                sql_input = "INSERT INTO Beams (%s) VALUES ('%s');\n" % \
+                            (','.join(col_names), "','".join(values).replace("'(NULL)'", "(NULL)"))
                 with open(file_path, "a") as text_file:
                     text_file.write(sql_input)
 
@@ -259,25 +280,25 @@ class DVH_SQL:
         if os.path.isfile(file_path):
             os.remove(file_path)
 
+        col_names = ['mrn', 'study_instance_uid', 'plan_name', 'fx_grp_name', 'fx_grp_number', 'fx_grp_count',
+                     'fx_dose', 'fxs', 'rx_dose', 'rx_percent', 'normalization_method', 'normalization_object',
+                     'import_time_stamp']
+
         for x in range(rx_table.count):
-            sql_input = [str(rx_table.mrn[x]),
-                         str(rx_table.study_instance_uid[x]),
-                         str(rx_table.plan_name[x]).replace("'", "`"),
-                         str(rx_table.fx_grp_name[x]),
-                         str(rx_table.fx_grp_number[x]),
-                         str(rx_table.fx_grp_count[x]),
-                         str(round(rx_table.fx_dose[x], 2)),
-                         str(rx_table.fxs[x]),
-                         str(round(rx_table.rx_dose[x], 2)),
-                         str(round(rx_table.rx_percent[x], 1)),
-                         str(rx_table.normalization_method[x]),
-                         str(rx_table.normalization_object[x]).replace("'", "`"),
-                         'NOW()']
-            sql_input = '\',\''.join(sql_input)
-            sql_input += '\');'
-            prepend = 'INSERT INTO Rxs VALUES (\''
-            sql_input = prepend + str(sql_input)
-            sql_input += '\n'
+            values = [str(rx_table.mrn[x]),
+                      str(rx_table.study_instance_uid[x]),
+                      str(rx_table.plan_name[x]).replace("'", "`"),
+                      str(rx_table.fx_grp_name[x]),
+                      str(rx_table.fx_grp_number[x]),
+                      str(rx_table.fx_grp_count[x]),
+                      str(round(rx_table.fx_dose[x], 2)),
+                      str(rx_table.fxs[x]),
+                      str(round(rx_table.rx_dose[x], 2)),
+                      str(round(rx_table.rx_percent[x], 1)),
+                      str(rx_table.normalization_method[x]),
+                      str(rx_table.normalization_object[x]).replace("'", "`"),
+                      'NOW()']
+            sql_input = "INSERT INTO Rxs (%s) VALUES ('%s');\n" % (','.join(col_names), "','".join(values))
             with open(file_path, "a") as text_file:
                 text_file.write(sql_input)
 
@@ -289,9 +310,11 @@ class DVH_SQL:
 
     def insert_dicom_file_row(self, mrn, uid, dir_name, plan_file, struct_file, dose_file):
 
-        sql_cmd = "INSERT INTO DICOM_Files VALUES ('%s', '%s', '%s', '%s', '%s', '%s', NOW());\n" % \
-                  (mrn, uid, dir_name, plan_file, struct_file, dose_file)
-        sql_cmd.replace("'(NULL)'", "(NULL)")
+        col_names = ['mrn', 'study_instance_uid', 'folder_path', 'plan_file', 'structure_file', 'dose_file',
+                     'import_time_stamp']
+        values = [mrn, uid, dir_name, plan_file, struct_file, dose_file]
+        sql_cmd = "INSERT INTO DICOM_Files (%s) VALUES ('%s', NOW());\n" % \
+                  (','.join(col_names), "','".join(values).replace("'(NULL)'", "(NULL)"))
         self.cursor.execute(sql_cmd)
         self.cnx.commit()
 
@@ -393,6 +416,9 @@ class DVH_SQL:
             condition = dvh_condition + condition
 
         return len(self.query('DVHs', 'mrn', condition))
+
+    def update_sql_tables(self):
+        self.get_column_names('DVHs')
 
 
 def write_import_errors(obj):

--- a/dvh/sql_connector.py
+++ b/dvh/sql_connector.py
@@ -133,9 +133,9 @@ class DVH_SQL:
                       str(round(dvh_table.surface_area[x], 2)),
                       '(NULL)',
                       dvh_table.centroid[x],
-                      dvh_table.spread_x[x],
-                      dvh_table.spread_y[x],
-                      dvh_table.spread_z[x],
+                      str(round(dvh_table.spread_x[x], 3)),
+                      str(round(dvh_table.spread_y[x], 3)),
+                      str(round(dvh_table.spread_z[x], 3)),
                       str(round(dvh_table.cross_section_max[x], 3)),
                       str(round(dvh_table.cross_section_median[x], 3)),
                       'NOW()']

--- a/dvh/utilities.py
+++ b/dvh/utilities.py
@@ -19,6 +19,13 @@ except:
     import dicom
 from get_settings import get_settings
 import pickle
+from math import ceil
+from shapely import speedups
+
+
+# Enable shapely calculations using C, as opposed to the C++ default
+if speedups.available:
+    speedups.enable()
 
 PREFERENCE_PATHS = {''}
 MIN_SLICE_THICKNESS = 2  # Update method to pull from DICOM
@@ -599,6 +606,192 @@ def calc_volume(roi):
     return round(volume / 1000., 2)
 
 
+def calc_centroid(roi):
+    """
+    :param roi: a "sets of points" formatted list
+    :return: centroid dicom coordinate in mm
+    :rtype: list
+    """
+    centroids = {'x': [], 'y': [], 'z': [], 'area': []}
+
+    for z in list(roi):
+        shapely_roi = points_to_shapely_polygon(roi[z])
+        if shapely_roi and shapely_roi.area > 0:
+            slice_centroid = shapely_roi.centroid
+            polygon_count = len(slice_centroid.xy[0])
+            for i in range(polygon_count):
+                centroids['x'].append(slice_centroid.xy[0][i])
+                centroids['y'].append(slice_centroid.xy[1][i])
+                centroids['z'].append(float(z))
+                if polygon_count > 1:
+                    centroids['area'].append(shapely_roi[i].area)
+                else:
+                    centroids['area'].append(shapely_roi.area)
+
+    x = np.array(centroids['x'])
+    y = np.array(centroids['y'])
+    z = np.array(centroids['z'])
+    w = np.array(centroids['area'])
+
+    centroid = [float(np.sum((x * w) / np.sum(w))),
+                float(np.sum((y * w) / np.sum(w))),
+                float(np.sum((z * w) / np.sum(w)))]
+
+    return centroid
+
+
+def update_centroid_in_db(study_instance_uid, roi_name):
+    """
+    This function will recalculate the centoid of an roi based on data in the SQL DB.
+    :param study_instance_uid: uid as specified in SQL DB
+    :param roi_name: roi_name as specified in SQL DB
+    """
+
+    coordinates_string = DVH_SQL().query('dvhs',
+                                         'roi_coord_string',
+                                         "study_instance_uid = '%s' and roi_name = '%s'"
+                                         % (study_instance_uid, roi_name))
+
+    roi = get_planes_from_string(coordinates_string[0][0])
+    centroid = calc_centroid(roi)
+
+    centroid = [str(round(v, 3)) for v in centroid]
+
+    DVH_SQL().update('dvhs',
+                     'centroid',
+                     ','.join(centroid),
+                     "study_instance_uid = '%s' and roi_name = '%s'"
+                     % (study_instance_uid, roi_name))
+
+
+def calc_cross_section(roi):
+    """
+    :param roi: a "sets of points" formatted list
+    :return: max and median cross-sectional area of all slices in cm^2
+    :rtype: list
+    """
+    areas = []
+
+    for z in list(roi):
+        shapely_roi = points_to_shapely_polygon(roi[z])
+        if shapely_roi and shapely_roi.area > 0:
+            slice_centroid = shapely_roi.centroid
+            polygon_count = len(slice_centroid.xy[0])
+            for i in range(polygon_count):
+                if polygon_count > 1:
+                    areas.append(shapely_roi[i].area)
+                else:
+                    areas.append(shapely_roi.area)
+
+    areas = np.array(areas)
+
+    area = {'max': float(np.max(areas) / 100.),
+            'median': float(np.median(areas) / 100.)}
+
+    return area
+
+
+def update_cross_section_in_db(study_instance_uid, roi_name):
+    """
+    This function will recalculate the centoid of an roi based on data in the SQL DB.
+    :param study_instance_uid: uid as specified in SQL DB
+    :param roi_name: roi_name as specified in SQL DB
+    """
+
+    coordinates_string = DVH_SQL().query('dvhs',
+                                         'roi_coord_string',
+                                         "study_instance_uid = '%s' and roi_name = '%s'"
+                                         % (study_instance_uid, roi_name))
+
+    roi = get_planes_from_string(coordinates_string[0][0])
+    area = calc_cross_section(roi)
+
+    DVH_SQL().update('dvhs',
+                     'cross_section_max',
+                     area['max'],
+                     "study_instance_uid = '%s' and roi_name = '%s'"
+                     % (study_instance_uid, roi_name))
+
+    DVH_SQL().update('dvhs',
+                     'cross_section_median',
+                     area['median'],
+                     "study_instance_uid = '%s' and roi_name = '%s'"
+                     % (study_instance_uid, roi_name))
+
+
+def calc_spread(roi):
+    """
+    :param roi: a "sets of points" formatted list
+    :return: x, y, z dimensions of a rectangular prism encompassing roi
+    :rtype: list
+    """
+    all_points = {'x': [], 'y': [], 'z': []}
+
+    for z in list(roi):
+        for polygon in roi[z]:
+            for point in polygon:
+                all_points['x'].append(point[0])
+                all_points['y'].append(point[1])
+                all_points['z'].append(point[2])
+
+    all_points = {'x': np.array(all_points['x']),
+                  'y': np.array(all_points['y']),
+                  'z': np.array(all_points['z'])}
+
+    if len(all_points['x'] > 0):
+        spread = [float(np.max(all_points[dim]) - np.min(all_points[dim])) for dim in ['x', 'y', 'z']]
+    else:
+        spread = [0, 0, 0]
+
+    return spread
+
+
+def update_spread_in_db(study_instance_uid, roi_name):
+    """
+    This function will recalculate the spread of an roi based on data in the SQL DB.
+    :param study_instance_uid: uid as specified in SQL DB
+    :param roi_name: roi_name as specified in SQL DB
+    """
+
+    coordinates_string = DVH_SQL().query('dvhs',
+                                         'roi_coord_string',
+                                         "study_instance_uid = '%s' and roi_name = '%s'"
+                                         % (study_instance_uid, roi_name))
+
+    roi = get_planes_from_string(coordinates_string[0][0])
+    spread = calc_spread(roi)
+
+    spread = [str(round(v/10., 3)) for v in spread]
+
+    DVH_SQL().update('dvhs',
+                     'spread_x',
+                     spread[0],
+                     "study_instance_uid = '%s' and roi_name = '%s'"
+                     % (study_instance_uid, roi_name))
+    DVH_SQL().update('dvhs',
+                     'spread_y',
+                     spread[1],
+                     "study_instance_uid = '%s' and roi_name = '%s'"
+                     % (study_instance_uid, roi_name))
+    DVH_SQL().update('dvhs',
+                     'spread_z',
+                     spread[2],
+                     "study_instance_uid = '%s' and roi_name = '%s'"
+                     % (study_instance_uid, roi_name))
+
+
+def calc_dth(min_distances):
+    """
+    :param min_distances:
+    :return: histogram of distances in 0.1mm bin widths
+    """
+
+    bin_count = int(ceil(np.max(min_distances) * 10.))
+    dst, bins = np.histogram(min_distances, bins=bin_count)
+
+    return dst
+
+
 def get_roi_coordinates_from_string(roi_coord_string):
     """
     :param roi_coord_string: the string reprentation of an roi in the SQL database
@@ -704,6 +897,8 @@ def update_min_distances_in_db(study_instance_uid, roi_name):
 
         try:
             min_distances = get_min_distances_to_target(oar_coordinates, tv_coordinates)
+            dth = calc_dth(min_distances)
+            dth_string = ','.join(['%.3f' % num for num in dth])
 
             DVH_SQL().update('dvhs',
                              'dist_to_ptv_min',
@@ -726,6 +921,12 @@ def update_min_distances_in_db(study_instance_uid, roi_name):
             DVH_SQL().update('dvhs',
                              'dist_to_ptv_max',
                              round(float(np.max(min_distances)), 2),
+                             "study_instance_uid = '%s' and roi_name = '%s'"
+                             % (study_instance_uid, roi_name))
+
+            DVH_SQL().update('dvhs',
+                             'dth_string',
+                             dth_string,
                              "study_instance_uid = '%s' and roi_name = '%s'"
                              % (study_instance_uid, roi_name))
         except:
@@ -760,6 +961,39 @@ def update_treatment_volume_overlap_in_db(study_instance_uid, roi_name):
         DVH_SQL().update('dvhs',
                          'ptv_overlap',
                          round(float(overlap), 2),
+                         "study_instance_uid = '%s' and roi_name = '%s'"
+                         % (study_instance_uid, roi_name))
+
+
+def update_dist_to_ptv_centroids_in_db(study_instance_uid, roi_name):
+    """
+    This function will recalculate the OARtoPTV centroid distance based on data in the SQL DB.
+    :param study_instance_uid: uid as specified in SQL DB
+    :param roi_name: roi_name as specified in SQL DB
+    """
+
+    oar_centroid_string = DVH_SQL().query('dvhs',
+                                          'centroid',
+                                          "study_instance_uid = '%s' and roi_name = '%s'"
+                                          % (study_instance_uid, roi_name))
+    oar_centroid = np.array([float(i) for i in oar_centroid_string[0][0].split(',')])
+
+    ptv_coordinates_strings = DVH_SQL().query('dvhs',
+                                              'roi_coord_string',
+                                              "study_instance_uid = '%s' and roi_type like 'PTV%%'"
+                                              % study_instance_uid)
+
+    if ptv_coordinates_strings:
+
+        ptvs = [get_planes_from_string(ptv[0]) for ptv in ptv_coordinates_strings]
+        tv = get_union(ptvs)
+        ptv_centroid = np.array(calc_centroid(tv))
+
+        dist_to_ptv_centroids = float(np.linalg.norm(ptv_centroid - oar_centroid)) / 10.
+
+        DVH_SQL().update('dvhs',
+                         'dist_to_ptv_centroids',
+                         round(dist_to_ptv_centroids, 3),
                          "study_instance_uid = '%s' and roi_name = '%s'"
                          % (study_instance_uid, roi_name))
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     name='dvh-analytics',
     include_package_data=True,
     packages=find_packages(),
-    version='0.4.3',
+    version='0.4.4',
     description='Create a database of DVHs, views with Bokeh',
     author='Dan Cutright',
     author_email='dan.cutright@gmail.com',


### PR DESCRIPTION
* typo in keyword for parameter in dicom_to_sql (import_latest_plan_only changes to import_latest_only)
* Shapely speedups enabled, if available
    * Shapely has calcs available in C, as opposed to C++
* centroid, dist_to_ptv_centroids, dth (distance to target histogram), spread_x, spread_y, spread_z, cross_section_max, 
cross_section_median, columns added to DVHs
    * These columns can be added by clicking Create Tables from Settings view, if running from source
    * Running from Docker or pip install shouldn't need to do this manually
* dist_to_ptv_centroids and dth must be calculated from Admin view after proper ROI name mapping
* dth_string calculated with Calc PTV Dist in Admin view
    * the string stored is csv representing a histogram with 0.1mm bins
* centroid, spread, and cross-sections also calculated at time of import
    * calc in Admin view only required for data imported prior to 0.4.4 install
* Admin view now specifies Post-Import calculations via dropdown
    * Added choice "Default Post-Import" to run through all calcs not done at time of DICOM import
* Endpoints for review DVH now calculated