### PR TITLE
0.5.2dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change log of DVH Analytics
 
+### 0.5.2 (TBD)
+* Beginning development for toxicity and protocol data
+    * New columns added to the Plans and DVHs SQL tables to tag toxicity scale and grade
+        * Toxicity grade must be a positive integer, default value is -1 indicating no reported toxicity
+        * New tab in Admin view to manage toxicity and protocol information
+    * New column added to Plans SQL table to indicate if a plan is part of a protocol
+    * Next version will have GUI in the Admin view to update this information more easily than via Database Editor
+* Input text for action selected by radio buttons in ROI Manager now properly updates based on current selections
+* If a plan for a given Study Instance UID is in your database when importing a plan with the same Study Instance UID,
+a message incorrectly indicated the plan was moved to the misc.  This message has been corrected and the files remain 
+in the inbox.
+* New radio button for Post Import Calculations easily allowing you calculate only missing values (instead of 
+recalculating the entire database or entering your own custom SQL condition)
+
 ### 0.5.1 (2019.1.7)
 * 0.5.0 Code was not running with pip install
     * Changed absolute imports to relative imports, some file reorganizing

--- a/dvh/modules/admin/roi_manager.py
+++ b/dvh/modules/admin/roi_manager.py
@@ -127,12 +127,12 @@ class RoiManager:
         # Button objects
         self.action_button = Button(label='Add Institutional ROI', button_type='primary',
                                     width=int(widget_width*(2./3)))
-        self.reload_button_roi = Button(label='Reload Map', button_type='primary', width=widget_width)
-        self.save_button_roi = Button(label='Map Saved', button_type='primary', width=widget_width)
-        self.ignore_button_roi = Button(label='Ignore', button_type='primary', width=widget_width/2)
-        self.delete_uncategorized_button_roi = Button(label='Delete DVH', button_type='warning', width=widget_width/2)
-        self.unignore_button_roi = Button(label='UnIgnore', button_type='primary', width=widget_width/2)
-        self.delete_ignored_button_roi = Button(label='Delete DVH', button_type='warning', width=widget_width/2)
+        self.reload_button_roi = Button(label='Reload Map', button_type='primary', width=widget_width-5)
+        self.save_button_roi = Button(label='Map Saved', button_type='primary', width=widget_width-5)
+        self.ignore_button_roi = Button(label='Ignore', button_type='primary', width=widget_width/2-5)
+        self.delete_uncategorized_button_roi = Button(label='Delete DVH', button_type='warning', width=widget_width/2-5)
+        self.unignore_button_roi = Button(label='UnIgnore', button_type='primary', width=widget_width/2-5)
+        self.delete_ignored_button_roi = Button(label='Delete DVH', button_type='warning', width=widget_width/2-5)
 
         self.remap_rois_function_map = {'Selected Physician': self.remap_all_rois_for_selected_physician,
                                         'Selected Physician Uncategorized': self.remap_uncategorized_rois_for_selected_physician,
@@ -223,14 +223,16 @@ class RoiManager:
                                  row(self.input_text, Spacer(width=30), self.action_button, Spacer(width=50),
                                      self.div_action),
                                  Div(text="<hr>", width=widget_width * 3),
-                                 row(self.select_uncategorized_variation, self.select_ignored_variation),
-                                 row(self.ignore_button_roi, self.delete_uncategorized_button_roi,
-                                     self.unignore_button_roi, self.delete_ignored_button_roi),
+                                 row(self.select_uncategorized_variation, Spacer(width=50),
+                                     self.select_ignored_variation),
+                                 row(self.ignore_button_roi, Spacer(width=10), self.delete_uncategorized_button_roi,
+                                     Spacer(width=50),
+                                     self.unignore_button_roi, Spacer(width=10), self.delete_ignored_button_roi),
                                  Div(text="<hr>", width=widget_width * 3),
                                  row(self.select_remap, self.remap_button),
                                  self.remap_checkbox_ignore,
                                  Div(text="<hr>", width=widget_width * 3),
-                                 row(self.reload_button_roi, self.save_button_roi)),
+                                 row(self.reload_button_roi, Spacer(width=10), self.save_button_roi)),
                           column(row(self.select_plot_display, Spacer(width=75), self.select_merge_physician_roi['a'],
                                      self.select_merge_physician_roi['b'], self.select_merge_physician_roi['button']),
                                  self.roi_map_plot,

--- a/dvh/modules/admin/roi_manager.py
+++ b/dvh/modules/admin/roi_manager.py
@@ -206,10 +206,10 @@ class RoiManager:
         self.roi_map_plot.segment(x0='x0', y0='y0', x1='x1', y1='y1', source=self.source_map, alpha=0.5)
         self.update_roi_map_source_data()
 
-        self.category_map = {0: self.select_institutional_roi.value,
-                             1: self.select_physician.value,
-                             2: self.select_physician_roi.value,
-                             3: self.select_variation.value}
+        self.category_map = {0: self.select_institutional_roi,
+                             1: self.select_physician,
+                             2: self.select_physician_roi,
+                             3: self.select_variation}
 
         self.layout = row(column(Div(text="<b>WARNING:</b> Buttons in orange cannot be easily undone.",
                                      width=widget_width*3+100),
@@ -443,7 +443,7 @@ class RoiManager:
 
     def update_input_text_value(self):
         if self.operator.active != 0:
-            self.input_text.value = self.category_map[self.category.active]
+            self.input_text.value = self.category_map[self.category.active].value
         elif self.operator.active == 0 and self.category.active == 3:
             self.input_text.value = self.select_uncategorized_variation.value
         else:
@@ -468,7 +468,7 @@ class RoiManager:
                    2: self.db.get_physician_rois(self.select_physician.value),
                    3: self.db.get_variations(self.select_physician.value, self.select_physician_roi.value)}
 
-        in_value = self.category_map[self.category.active]
+        in_value = self.category_map[self.category.active].value
 
         input_text_value = clean_name(self.input_text.value)
         if self.category.active == 1:

--- a/dvh/modules/default_options.py
+++ b/dvh/modules/default_options.py
@@ -7,7 +7,7 @@ Created on Sat Oct 28 2017
 import os
 import paths
 
-VERSION = '0.5.1'
+VERSION = '0.5.2'
 
 # Setting this to true enables log in screens
 # You must add your own code in into check_credentials of auth.py

--- a/dvh/modules/main/categories.py
+++ b/dvh/modules/main/categories.py
@@ -22,7 +22,9 @@ class Categories:
                          'Scan Mode': {'var_name': 'scan_mode', 'table': 'Beams'},
                          'MRN': {'var_name': 'mrn', 'table': 'Plans'},
                          'UID': {'var_name': 'study_instance_uid', 'table': 'Plans'},
-                         'Baseline': {'var_name': 'baseline', 'table': 'Plans'}}
+                         'Baseline': {'var_name': 'baseline', 'table': 'Plans'},
+                         'Toxicity Scale': {'var_name': 'toxicity_scale', 'table': 'DVHs'},
+                         'Protocol': {'var_name': 'protocol', 'table': 'Plans'}}
 
         # This is a maps quantitative data type selections to SQL columns and SQL tables, and the bokeh source
         self.range = {'Age': {'var_name': 'age', 'table': 'Plans', 'units': '', 'source': sources.plans},
@@ -72,7 +74,8 @@ class Categories:
                       'Beam MU per deg': {'var_name': 'beam_mu_per_deg', 'table': 'Beams', 'units': '', 'source': sources.beams},
                       'Beam MU per control point': {'var_name': 'beam_mu_per_cp', 'table': 'Beams', 'units': '', 'source': sources.beams},
                       'ROI Cross-Section Max': {'var_name': 'cross_section_max', 'table': 'DVHs', 'units': 'cm^2', 'source': sources.dvhs},
-                      'ROI Cross-Section Median': {'var_name': 'cross_section_median', 'table': 'DVHs', 'units': 'cm^2', 'source': sources.dvhs}}
+                      'ROI Cross-Section Median': {'var_name': 'cross_section_median', 'table': 'DVHs', 'units': 'cm^2', 'source': sources.dvhs},
+                      'Toxicity Grade': {'var_name': 'toxicity_grade', 'table': 'DVHs', 'units': '', 'source': sources.dvhs}}
 
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         # Correlation and Regression variable names
@@ -82,7 +85,7 @@ class Categories:
         self.correlation_variables_beam = ['Beam Dose', 'Beam MU', 'Control Point Count', 'Gantry Range',
                                            'SSD', 'Beam MU per control point']
         for key in list(self.range):
-            if key.startswith('ROI') or key.startswith('PTV') or key in {'Total Plan MU', 'Rx Dose'}:
+            if key.startswith('ROI') or key.startswith('PTV') or key in {'Total Plan MU', 'Rx Dose', 'Toxicity Grade'}:
                 self.correlation_variables.append(key)
                 self.correlation_names.append(key)
             if key in self.correlation_variables_beam:

--- a/dvh/modules/main/query.py
+++ b/dvh/modules/main/query.py
@@ -792,7 +792,7 @@ class Query:
         attributes = ['rx_dose', 'volume', 'surface_area', 'min_dose', 'mean_dose', 'max_dose', 'dist_to_ptv_min',
                       'dist_to_ptv_median', 'dist_to_ptv_mean', 'dist_to_ptv_max', 'dist_to_ptv_centroids',
                       'ptv_overlap', 'cross_section_max', 'cross_section_median', 'spread_x', 'spread_y',
-                      'spread_z']
+                      'spread_z', 'toxicity_grade']
         if extra_rows > 0:
             dvh.study_instance_uid.extend(['N/A'] * extra_rows)
             dvh.institutional_roi.extend(['N/A'] * extra_rows)
@@ -832,6 +832,7 @@ class Query:
         dvh.spread_x.insert(0, 'N/A')
         dvh.spread_y.insert(0, 'N/A')
         dvh.spread_z.insert(0, 'N/A')
+        dvh.toxicity_grade.insert(0, -1)
         line_colors.insert(0, options.REVIEW_DVH_COLOR)
         x_data.insert(0, [0])
         y_data.insert(0, [0])
@@ -870,7 +871,8 @@ class Query:
                                   'y': y_data,
                                   'color': line_colors,
                                   'x_scale': x_scale,
-                                  'y_scale': y_scale}
+                                  'y_scale': y_scale,
+                                  'toxicity_grade': dvh.toxicity_grade}
 
         print(str(datetime.now()), 'begin updating beam, plan, rx data sources', sep=' ')
         self.update_beam_data(dvh.study_instance_uid)

--- a/dvh/modules/tools/io/database/dicom/importer.py
+++ b/dvh/modules/tools/io/database/dicom/importer.py
@@ -50,7 +50,7 @@ def dicom_to_sql(start_path=None, force_update=False, move_files=True,
             print("The UID from the following files is already imported.")
             if not force_update:
                 print("Must delete content associated with this UID from database before reimporting.")
-                print("These files have been moved into the 'misc' folder within your 'imported' folder.")
+                print('WARNING: These files will remain in their current location.')
                 for file_type in FILE_TYPES:
                     print(file_paths[uid][file_type]['file_path'])
                 print("The UID is %s" % uid)
@@ -108,7 +108,7 @@ def dicom_to_sql(start_path=None, force_update=False, move_files=True,
             print('WARNING: Missing complete set of plan, struct, and dose files for uid %s' % uid)
             if not force_update:
                 print('WARNING: Skipping this import. If you wish to import an incomplete DICOM set, use Force Update')
-                print('WARNING: The current file will be moved to the misc folder with in your imported folder')
+                print('WARNING: Files with this UID will remain in their current location.')
                 continue
 
         if plan_file:
@@ -182,6 +182,7 @@ def dicom_to_sql(start_path=None, force_update=False, move_files=True,
 
 def get_file_paths(start_path):
     print('Collecting DICOM file paths')
+    start_time = datetime.now()
     f = []
     for root, dirs, files in os.walk(start_path, topdown=False):
         for name in files:
@@ -191,7 +192,7 @@ def get_file_paths(start_path):
     file_paths = {}
     for file_path in f:
         try:
-            dicom_file = dicom.read_file(file_path)
+            dicom_file = dicom.read_file(file_path, defer_size='2KB', stop_before_pixels=True)
         except:
             dicom_file = False
 
@@ -222,7 +223,8 @@ def get_file_paths(start_path):
                 file_paths[uid][file_type]['latest_file'] = file_paths[uid][file_type]['file_path'][latest_index]
             else:
                 file_paths[uid][file_type]['latest_file'] = []
-    print('DICOM file paths collected')
+    end_time = datetime.now()
+    print_run_time(start_time, end_time, 'DICOM file paths collected. This')
     return file_paths
 
 

--- a/dvh/modules/tools/io/database/sql_connector.py
+++ b/dvh/modules/tools/io/database/sql_connector.py
@@ -115,7 +115,7 @@ class DVH_SQL:
                      'volume', 'min_dose', 'mean_dose', 'max_dose', 'dvh_string', 'roi_coord_string',
                      'dist_to_ptv_min', 'dist_to_ptv_mean', 'dist_to_ptv_median', 'dist_to_ptv_max', 'surface_area',
                      'ptv_overlap', 'centroid', 'spread_x', 'spread_y', 'spread_z', 'cross_section_max',
-                     'cross_section_median', 'import_time_stamp']
+                     'cross_section_median', 'import_time_stamp', 'toxicity_scale', 'toxicity_grade']
 
         # Import each ROI from ROI_PyTable, append to output text file
         if max(dvh_table.ptv_number) > 1:
@@ -150,7 +150,9 @@ class DVH_SQL:
                       str(round(dvh_table.spread_z[x], 3)),
                       str(round(dvh_table.cross_section_max[x], 3)),
                       str(round(dvh_table.cross_section_median[x], 3)),
-                      'NOW()']
+                      'NOW()',
+                      '(NULL)',
+                      '-1']
 
             cmd = "INSERT INTO DVHs (%s) VALUES ('%s');\n" % \
                   (','.join(col_names), "','".join(values).replace("'(NULL)'", "(NULL)"))
@@ -175,7 +177,7 @@ class DVH_SQL:
                      'tx_site', 'rx_dose', 'fxs', 'patient_orientation', 'plan_time_stamp', 'struct_time_stamp',
                      'dose_time_stamp', 'tps_manufacturer', 'tps_software_name', 'tps_software_version', 'tx_modality',
                      'tx_time', 'total_mu', 'dose_grid_res', 'heterogeneity_correction', 'baseline',
-                     'import_time_stamp']
+                     'import_time_stamp', 'toxicity_scales', 'toxicity_grades', 'protocol']
         plan.physician = truncate_string(plan.physician, 50)
         plan.tx_site = truncate_string(plan.tx_site, 50)
         plan.tps_manufacturer = truncate_string(plan.tps_manufacturer, 50)
@@ -204,7 +206,10 @@ class DVH_SQL:
                   plan.dose_grid_resolution,
                   plan.heterogeneity_correction,
                   'false',
-                  'NOW()']
+                  'NOW()',
+                  "(NULL)",
+                  "(NULL)",
+                  "(NULL)"]
 
         cmd = "INSERT INTO Plans (%s) VALUES ('%s');\n" % \
               (','.join(col_names), "','".join(values).replace("'(NULL)'", "(NULL)"))
@@ -401,6 +406,8 @@ class DVH_SQL:
         self.cursor.execute(query)
         cursor_return = self.cursor.fetchall()
         unique_values = [str(uv[0]) for uv in cursor_return]
+        if not unique_values:
+            unique_values = ['']
         unique_values.sort()
         return unique_values
 

--- a/dvh/preferences/create_tables.sql
+++ b/dvh/preferences/create_tables.sql
@@ -12,3 +12,9 @@ ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS spread_y real;
 ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS spread_z real;
 ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS cross_section_max real;
 ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS cross_section_median real;
+-- The following columns have been added as of DVH Analytics 0.5.2
+ALTER TABLE Plans ADD COLUMN IF NOT EXISTS toxicity_scales text;
+ALTER TABLE Plans ADD COLUMN IF NOT EXISTS toxicity_grades text;
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS toxicity_scale text;
+ALTER TABLE DVHs ADD COLUMN IF NOT EXISTS toxicity_grade smallint;
+ALTER TABLE Plans ADD COLUMN IF NOT EXISTS protocol text;


### PR DESCRIPTION
* Beginning development for toxicity and protocol data
    * New columns added to the Plans and DVHs SQL tables to tag toxicity scale and grade
        * Toxicity grade must be a positive integer, default value is -1 indicating no reported toxicity
        * New tab in Admin view to manage toxicity and protocol information
    * New column added to Plans SQL table to indicate if a plan is part of a protocol
    * Next version will have GUI in the Admin view to update this information more easily than via Database Editor
* Input text for action selected by radio buttons in ROI Manager now properly updates based on current selections
* If a plan for a given Study Instance UID is in your database when importing a plan with the same Study Instance UID,
a message incorrectly indicated the plan was moved to the misc.  This message has been corrected and the files remain 
in the inbox.
* New radio button for Post Import Calculations easily allowing you calculate only missing values (instead of 
recalculating the entire database or entering your own custom SQL condition)