### PR TITLE
0.5.4dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log of DVH Analytics
 
-### 0.5.4 (TBD)
+### 0.5.4 (2019.2.11)
 * In the Regression tab, plotting any variable with min, median, mean, or max crashed on axis title update. Fixed.
 * Min, mean, median and max of beam complexity, beam area, control point MU now calculated at time of import
     * These new values are available for time-series, correlation, and regression tabs in the main view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### 0.5.4 (TBD)
 * In the Regression tab, plotting any variable with min, median, mean, or max crashed on axis title update. Fixed.
-
+* Min, mean, median and max of beam complexity, beam area, control point MU now calculated at time of import
+    * These new values are available for time-series, correlation, and regression tabs in the main view
+* Terminal now prints mrn of excluded plans due to non-numeral data used for correlation / regression
 
 ### 0.5.3 (2019.1.31)
 * Bokeh >=1.0.4 now required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log of DVH Analytics
 
+### 0.5.4 (TBD)
+* In the Regression tab, plotting any variable with min, median, mean, or max crashed on axis title update. Fixed.
+
+
 ### 0.5.3 (2019.1.31)
 * Bokeh >=1.0.4 now required
 * Import Notes tab added to Admin view for quick reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Min, mean, median and max of beam complexity, beam area, control point MU now calculated at time of import
     * These new values are available for time-series, correlation, and regression tabs in the main view
 * Terminal now prints mrn of excluded plans due to non-numeral data used for correlation / regression
+* Fixed bug causing crash at import due to some now missing SQL columns
 
 ### 0.5.3 (2019.1.31)
 * Bokeh >=1.0.4 now required

--- a/dvh/modules/admin/database_editor.py
+++ b/dvh/modules/admin/database_editor.py
@@ -98,8 +98,8 @@ class DatabaseEditor:
         self.calculations_title = Div(text="<b>Post Import Calculations</b>", width=column_width)
         self.calculate_condition = TextInput(value='', title="Condition:", width=350)
         self.calculate_options = ['Default Post-Import', 'PTV Distances', 'PTV Overlap', 'ROI Centroid',
-                                  'ROI Spread', 'ROI Cross-Section', 'OAR-PTV Centroid Dist', 'All (except age)',
-                                  'Patient Ages']
+                                  'ROI Spread', 'ROI Cross-Section', 'OAR-PTV Centroid Dist', 'Plan Complexities',
+                                  'All (except age)', 'Patient Ages']
         self.calculate_select = Select(value=self.calculate_options[0], options=self.calculate_options,
                                        title='Calculate:', width=150)
         self.calculate_missing_only = CheckboxGroup(labels=['Only Calculate Missing Values'], active=[0], width=280)
@@ -305,6 +305,8 @@ class DatabaseEditor:
             null_variable = 'spread_x'
         elif variable == 'cross_section':
             null_variable = 'cross_section_max'
+        elif variable == 'plan_complexity':
+            null_variable = 'complexity'
 
         final_condition = {True: ["(%s is NULL)" % null_variable], False: []}[0 in self.calculate_missing_only.active]
         if condition and condition[0]:
@@ -334,6 +336,14 @@ class DatabaseEditor:
     def update_all_dist_to_ptv_centoids_in_db(self, condition):
         self.update_all('ptv_centroids', condition)
 
+    def update_all_plan_complexities_in_db(self, condition):
+        final_condition = {True: ["(complexity is NULL)"], False: []}[0 in self.calculate_missing_only.active]
+        if condition and condition[0]:
+            final_condition.append('(%s)' % condition[0])
+        final_condition = ' AND '.join(final_condition)
+
+        db_update.plan_complexities(final_condition)
+
     def update_all_except_age_in_db(self, *condition):
         for f in self.calculate_select.options:
             if f not in {'Patient Ages', 'Default Post-Import'}:
@@ -341,7 +351,7 @@ class DatabaseEditor:
                 self.calculate_exec()
 
     def update_default_post_import(self, *condition):
-        for f in ['PTV Distances', 'PTV Overlap', 'OAR-PTV Centroid Dist']:
+        for f in ['PTV Distances', 'PTV Overlap', 'OAR-PTV Centroid Dist', 'Plan Complexities']:
             self.calculate_select.value = f
             self.calculate_exec()
         self.calculate_select.value = 'Default Post-Import'
@@ -429,6 +439,7 @@ class DatabaseEditor:
                     'ROI Spread': self.update_all_spreads_in_db,
                     'ROI Cross-Section': self.update_all_cross_sections_in_db,
                     'OAR-PTV Centroid Dist': self.update_all_dist_to_ptv_centoids_in_db,
+                    'Plan Complexities': self.update_all_plan_complexities_in_db,
                     'All (except age)': self.update_all_except_age_in_db,
                     'Default Post-Import': self.update_default_post_import}
 

--- a/dvh/modules/default_options.py
+++ b/dvh/modules/default_options.py
@@ -7,7 +7,7 @@ Created on Sat Oct 28 2017
 import os
 import paths
 
-VERSION = '0.5.3'
+VERSION = '0.5.4'
 
 # Setting this to true enables log in screens
 # You must add your own code in into check_credentials of auth.py

--- a/dvh/modules/default_options.py
+++ b/dvh/modules/default_options.py
@@ -92,7 +92,7 @@ HISTOGRAM_1_ALPHA = 0.3
 HISTOGRAM_2_ALPHA = 0.3
 
 # Default selections for teh correlation matrix
-CORRELATION_MATRIX_DEFAULTS_1 = list(range(20, 28)) + [29, 30]
+CORRELATION_MATRIX_DEFAULTS_1 = list(range(32, 39)) + [41, 42, 43]
 CORRELATION_MATRIX_DEFAULTS_2 = list(range(0, 3))
 
 # Options for the plot in the Multi-Variable Regression tab

--- a/dvh/modules/main/categories.py
+++ b/dvh/modules/main/categories.py
@@ -74,7 +74,20 @@ class Categories:
                       'Beam MU per control point': {'var_name': 'beam_mu_per_cp', 'table': 'Beams', 'units': '', 'source': sources.beams},
                       'ROI Cross-Section Max': {'var_name': 'cross_section_max', 'table': 'DVHs', 'units': 'cm^2', 'source': sources.dvhs},
                       'ROI Cross-Section Median': {'var_name': 'cross_section_median', 'table': 'DVHs', 'units': 'cm^2', 'source': sources.dvhs},
-                      'Toxicity Grade': {'var_name': 'toxicity_grade', 'table': 'DVHs', 'units': '', 'source': sources.dvhs}}
+                      'Toxicity Grade': {'var_name': 'toxicity_grade', 'table': 'DVHs', 'units': '', 'source': sources.dvhs},
+                      'Plan Complexity': {'var_name': 'complexity', 'table': 'Plans', 'units': '', 'source': sources.plans},
+                      'Beam Complexity (Min)': {'var_name': 'complexity_min', 'table': 'Beams', 'units': '', 'source': sources.beams},
+                      'Beam Complexity (Mean)': {'var_name': 'complexity_mean', 'table': 'Beams', 'units': '', 'source': sources.beams},
+                      'Beam Complexity (Median)': {'var_name': 'complexity_median', 'table': 'Beams', 'units': '', 'source': sources.beams},
+                      'Beam Complexity (Max)': {'var_name': 'complexity_max', 'table': 'Beams', 'units': '', 'source': sources.beams},
+                      'Beam Area (Min)': {'var_name': 'area_min', 'table': 'Beams', 'units': 'cm^2', 'source': sources.beams},
+                      'Beam Area (Mean)': {'var_name': 'area_mean', 'table': 'Beams', 'units': 'cm^2', 'source': sources.beams},
+                      'Beam Area (Median)': {'var_name': 'area_median', 'table': 'Beams', 'units': 'cm^2', 'source': sources.beams},
+                      'Beam Area (Max)': {'var_name': 'area_max', 'table': 'Beams', 'units': 'cm^2', 'source': sources.beams},
+                      'CP MU (Min)': {'var_name': 'cp_mu_min', 'table': 'Beams', 'units': '', 'source': sources.beams},
+                      'CP MU (Mean)': {'var_name': 'cp_mu_mean', 'table': 'Beams', 'units': '', 'source': sources.beams},
+                      'CP MU (Median)': {'var_name': 'cp_mu_median', 'table': 'Beams', 'units': '', 'source': sources.beams},
+                      'CP MU (Max)': {'var_name': 'cp_mu_max', 'table': 'Beams', 'units': '', 'source': sources.beams}}
 
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         # Correlation and Regression variable names
@@ -84,7 +97,8 @@ class Categories:
         self.correlation_variables_beam = ['Beam Dose', 'Beam MU', 'Control Point Count', 'Gantry Range',
                                            'SSD', 'Beam MU per control point']
         for key in list(self.range):
-            if key.startswith('ROI') or key.startswith('PTV') or key in {'Total Plan MU', 'Rx Dose', 'Toxicity Grade'}:
+            if key.startswith('ROI') or key.startswith('PTV') or 'Beam Complexity' in key or 'Beam Area' in key or \
+                    'CP MU' in key or key in {'Total Plan MU', 'Rx Dose', 'Toxicity Grade', 'Plan Complexity'}:
                 self.correlation_variables.append(key)
                 self.correlation_names.append(key)
             if key in self.correlation_variables_beam:

--- a/dvh/modules/main/correlation.py
+++ b/dvh/modules/main/correlation.py
@@ -212,8 +212,8 @@ class Correlation:
                             current_uid = self.data[n][range_var]['uid'][i]
                             if current_uid not in self.bad_uid[n]:
                                 self.bad_uid[n].append(current_uid)
-                            print("%s[%s] is non-numerical, will remove this patient from correlation data"
-                                  % (range_var, i))
+                            print("%s[%s] (mrn: %s) is non-numerical, will remove this patient from correlation data"
+                                  % (range_var, i, self.data[n][range_var]['mrn'][i]))
 
                 new_correlation = {}
                 for range_var in list(self.data[n]):
@@ -263,7 +263,7 @@ class Correlation:
             table = self.range_categories[key]['table']
             units = self.range_categories[key]['units']
 
-            if table in {'Plans'}:
+            if table in {'Plans'} or key.startswith('Beam Complexity') or key.startswith('Beam Area') or key.startswith('CP MU'):
                 temp = {n: {k: [] for k in temp_keys} for n in GROUP_LABELS}
                 temp['units'] = units
 
@@ -288,7 +288,7 @@ class Correlation:
 
             stats = ['min', 'mean', 'median', 'max']
 
-            if table in {'Beams'}:
+            if table in {'Beams'} and not (key.startswith('Beam Complexity') or key.startswith('Beam Area') or key.startswith('CP MU')):
                 beam_keys = stats + ['uid', 'mrn']
                 temp = {n: {bk: [] for bk in beam_keys} for n in GROUP_LABELS}
                 for n in GROUP_LABELS:

--- a/dvh/modules/main/query.py
+++ b/dvh/modules/main/query.py
@@ -568,7 +568,10 @@ class Query:
                       'gantry_end', 'gantry_rot_dir', 'gantry_range', 'gantry_min', 'gantry_max', 'collimator_start',
                       'collimator_end', 'collimator_rot_dir', 'collimator_range', 'collimator_min', 'collimator_max',
                       'couch_start', 'couch_end', 'couch_rot_dir', 'couch_range', 'couch_min', 'couch_max',
-                      'radiation_type', 'ssd', 'treatment_machine']
+                      'radiation_type', 'ssd', 'treatment_machine', 'area_min']
+        for i in ['min', 'mean', 'median', 'max']:
+            for j in ['area', 'complexity', 'cp_mu']:
+                attributes.append('%s_%s' % (j, i))
         data = {attr: getattr(beam_data, attr) for attr in attributes}
         data['anon_id'] = anon_id
         data['group'] = groups
@@ -588,9 +591,8 @@ class Query:
         anon_id = [self.anon_id_map[plan_data.mrn[i]] for i in range(len(plan_data.mrn))]
 
         attributes = ['mrn', 'age', 'birth_date', 'dose_grid_res', 'fxs', 'patient_orientation', 'patient_sex',
-                      'physician',
-                      'rx_dose', 'sim_study_date', 'total_mu', 'tx_modality', 'tx_site', 'heterogeneity_correction',
-                      'baseline']
+                      'physician', 'rx_dose', 'sim_study_date', 'total_mu', 'tx_modality', 'tx_site',
+                      'heterogeneity_correction', 'complexity']
         data = {attr: getattr(plan_data, attr) for attr in attributes}
         data['anon_id'] = anon_id
         data['group'] = groups

--- a/dvh/modules/main/regression.py
+++ b/dvh/modules/main/regression.py
@@ -164,9 +164,6 @@ class Regression:
         axis_label = ''
 
         if new:
-
-            time_series_new = new  # time_series.range_categories needs this key
-            # If new has something in parenthesis, extract and put in front
             new_split = new.split(' (')
             if len(new_split) > 1:
                 new_display = "%s %s" % (new_split[1].split(')')[0], new_split[0])
@@ -180,8 +177,8 @@ class Regression:
                 axis_label = 'EUD (Gy)'
             elif new == 'NTCP/TCP':
                 axis_label = 'NTCP or TCP'
-            elif self.time_series.range_categories[time_series_new]['units']:
-                axis_label = "%s (%s)" % (new_display, self.time_series.range_categories[time_series_new]['units'])
+            elif self.time_series.range_categories[new_split[0]]['units']:
+                axis_label = "%s (%s)" % (new_display, self.time_series.range_categories[new_split[0]]['units'])
             else:
                 axis_label = new_display
 

--- a/dvh/modules/main/regression.py
+++ b/dvh/modules/main/regression.py
@@ -337,4 +337,5 @@ class Regression:
             self.y.value = ''
 
     def update_residual_y_axis_label(self):
-        self.residual_figure.yaxis.axis_label = self.get_axis_label(self.x)
+        # self.residual_figure.yaxis.axis_label = self.get_axis_label(self.x)
+        self.residual_figure.yaxis.axis_label = 'Residual'

--- a/dvh/modules/main/regression.py
+++ b/dvh/modules/main/regression.py
@@ -164,6 +164,7 @@ class Regression:
         axis_label = ''
 
         if new:
+            new_original = str(new)
             new_split = new.split(' (')
             if len(new_split) > 1:
                 new_display = "%s %s" % (new_split[1].split(')')[0], new_split[0])
@@ -177,6 +178,8 @@ class Regression:
                 axis_label = 'EUD (Gy)'
             elif new == 'NTCP/TCP':
                 axis_label = 'NTCP or TCP'
+            elif 'PTV Distance' in new:
+                axis_label = "%s (%s)" % (new_display, self.time_series.range_categories[new_original]['units'])
             elif self.time_series.range_categories[new_split[0]]['units']:
                 axis_label = "%s (%s)" % (new_display, self.time_series.range_categories[new_split[0]]['units'])
             else:

--- a/dvh/modules/main/regression.py
+++ b/dvh/modules/main/regression.py
@@ -320,7 +320,7 @@ class Regression:
                                                                            'db_value': self.correlation.data[n][self.y.value]['data']}
                 else:
                     for k in ['multi_var_coeff_results', 'multi_var_model_results', 'residual_chart']:
-                        clear_source_data(self.sources, '%s_%s'(k, n))
+                        clear_source_data(self.sources, '%s_%s' % (k, n))
 
     def multi_var_include_selection(self, attr, old, new):
         row_index = self.sources.multi_var_include.selected.indices[0]

--- a/dvh/modules/main/regression.py
+++ b/dvh/modules/main/regression.py
@@ -164,11 +164,9 @@ class Regression:
         axis_label = ''
 
         if new:
-            new_original = str(new)
             new_split = new.split(' (')
             if len(new_split) > 1:
                 new_display = "%s %s" % (new_split[1].split(')')[0], new_split[0])
-                new = new_split[0]
             else:
                 new_display = new
 
@@ -179,7 +177,7 @@ class Regression:
             elif new == 'NTCP/TCP':
                 axis_label = 'NTCP or TCP'
             elif 'PTV Distance' in new:
-                axis_label = "%s (%s)" % (new_display, self.time_series.range_categories[new_original]['units'])
+                axis_label = "%s (%s)" % (new_display, self.time_series.range_categories[new]['units'])
             elif self.time_series.range_categories[new_split[0]]['units']:
                 axis_label = "%s (%s)" % (new_display, self.time_series.range_categories[new_split[0]]['units'])
             else:

--- a/dvh/modules/tools/io/database/sql_connector.py
+++ b/dvh/modules/tools/io/database/sql_connector.py
@@ -122,7 +122,7 @@ class DVH_SQL:
                      'volume', 'min_dose', 'mean_dose', 'max_dose', 'dvh_string', 'roi_coord_string',
                      'dist_to_ptv_min', 'dist_to_ptv_mean', 'dist_to_ptv_median', 'dist_to_ptv_max', 'surface_area',
                      'ptv_overlap', 'centroid', 'spread_x', 'spread_y', 'spread_z', 'cross_section_max',
-                     'cross_section_median', 'import_time_stamp', 'toxicity_scale', 'toxicity_grade']
+                     'cross_section_median', 'import_time_stamp', 'toxicity_grade']
 
         # Import each ROI from ROI_PyTable, append to output text file
         if max(dvh_table.ptv_number) > 1:
@@ -158,7 +158,6 @@ class DVH_SQL:
                       str(round(dvh_table.cross_section_max[x], 3)),
                       str(round(dvh_table.cross_section_median[x], 3)),
                       'NOW()',
-                      '(NULL)',
                       '-1']
 
             cmd = "INSERT INTO DVHs (%s) VALUES ('%s');\n" % \
@@ -184,7 +183,7 @@ class DVH_SQL:
                      'tx_site', 'rx_dose', 'fxs', 'patient_orientation', 'plan_time_stamp', 'struct_time_stamp',
                      'dose_time_stamp', 'tps_manufacturer', 'tps_software_name', 'tps_software_version', 'tx_modality',
                      'tx_time', 'total_mu', 'dose_grid_res', 'heterogeneity_correction', 'baseline',
-                     'import_time_stamp', 'toxicity_scales', 'toxicity_grades', 'protocol']
+                     'import_time_stamp', 'toxicity_grades', 'protocol']
         plan.physician = truncate_string(plan.physician, 50)
         plan.tx_site = truncate_string(plan.tx_site, 50)
         plan.tps_manufacturer = truncate_string(plan.tps_manufacturer, 50)
@@ -215,7 +214,6 @@ class DVH_SQL:
                   'false',
                   'NOW()',
                   "(NULL)",
-                  "(NULL)",
                   "(NULL)"]
 
         cmd = "INSERT INTO Plans (%s) VALUES ('%s');\n" % \
@@ -243,7 +241,10 @@ class DVH_SQL:
                      'collimator_rot_dir', 'collimator_range', 'collimator_min', 'collimator_max', 'couch_start',
                      'couch_end', 'couch_rot_dir', 'couch_range', 'couch_min', 'couch_max', 'beam_dose_pt', 'isocenter',
                      'ssd', 'treatment_machine', 'scan_mode', 'scan_spot_count', 'beam_mu_per_deg', 'beam_mu_per_cp',
-                     'import_time_stamp']
+                     'import_time_stamp', 'area_min', 'area_mean', 'area_median', 'area_max', 'x_perim_min',
+                     'x_perim_mean', 'x_perim_median', 'x_perim_max', 'y_perim_min', 'y_perim_mean', 'y_perim_median',
+                     'y_perim_max', 'complexity_min', 'complexity_mean', 'complexity_median', 'complexity_max',
+                     'cp_mu_min', 'cp_mu_mean', 'cp_mu_median', 'cp_mu_max']
 
         # Import each ROI from ROI_PyTable, append to output text file
         for x in range(beams.count):
@@ -289,7 +290,12 @@ class DVH_SQL:
                           str(beams.scan_spot_count[x]),
                           str(beams.beam_mu_per_deg[x]),
                           str(beams.beam_mu_per_cp[x]),
-                          'NOW()']
+                          'NOW()',
+                          str(beams.area_min[x]), str(beams.area_mean[x]), str(beams.area_median[x]), str(beams.area_max[x]),
+                          str(beams.x_perim_min[x]), str(beams.x_perim_mean[x]), str(beams.x_perim_median[x]), str(beams.x_perim_max[x]),
+                          str(beams.y_perim_min[x]), str(beams.y_perim_mean[x]), str(beams.y_perim_median[x]), str(beams.y_perim_max[x]),
+                          str(beams.complexity_min[x]), str(beams.complexity_mean[x]), str(beams.complexity_median[x]), str(beams.complexity_max[x]),
+                          str(beams.cp_mu_min[x]), str(beams.cp_mu_mean[x]), str(beams.cp_mu_median[x]), str(beams.cp_mu_max[x])]
                 sql_input = "INSERT INTO Beams (%s) VALUES ('%s');\n" % \
                             (','.join(col_names), "','".join(values).replace("'(NULL)'", "(NULL)"))
 
@@ -416,8 +422,9 @@ class DVH_SQL:
             unique_values = [str(uv[0]) for uv in cursor_return if str(uv[0])]
         else:
             unique_values = [str(uv[0]) for uv in cursor_return]
-        if not unique_values:
-            unique_values = ['']
+        if not unique_values and 'return_empty' not in kwargs:
+            if 'return_empty' not in kwargs or ('return_empty' in kwargs and not kwargs['return_empty']):
+                unique_values = ['']
         unique_values.sort()
         return unique_values
 

--- a/dvh/modules/tools/mlc_analyzer.py
+++ b/dvh/modules/tools/mlc_analyzer.py
@@ -72,7 +72,7 @@ class FxGroup:
 
 
 class Beam:
-    def __init__(self, beam_seq, meter_set):
+    def __init__(self, beam_seq, meter_set, ignore_zero_mu_cp=False):
 
         cp_seq = beam_seq.ControlPointSequence
         self.control_point = [ControlPoint(cp) for cp in cp_seq]
@@ -128,6 +128,11 @@ class Beam:
         for key in self.summary:
             if len(self.summary[key]) == 1:
                 self.summary[key] = self.summary[key] * len(self.summary['cp'])
+
+        if ignore_zero_mu_cp:
+            non_zero_indices = [i for i, value in enumerate(self.summary['cp_mu']) if value != 0]
+            for key in list(self.summary):
+                self.summary[key] = [self.summary[key][i] for i in non_zero_indices]
 
 
 class ControlPoint:

--- a/dvh/preferences/create_tables.sql
+++ b/dvh/preferences/create_tables.sql
@@ -21,3 +21,25 @@ ALTER TABLE Plans ADD COLUMN IF NOT EXISTS protocol text;
 -- The following columns have been added as of DVH Analytics 0.5.3
 ALTER TABLE Plans DROP COLUMN IF EXISTS toxicity_scales;
 ALTER TABLE DVHs DROP COLUMN IF EXISTS toxicity_scale;
+-- The following columns have been added as of DVH Analytics 0.5.4
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS area_min real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS area_mean real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS area_median real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS area_max real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS x_perim_min real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS x_perim_mean real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS x_perim_median real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS x_perim_max real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS y_perim_min real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS y_perim_mean real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS y_perim_median real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS y_perim_max real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS complexity_min real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS complexity_mean real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS complexity_median real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS complexity_max real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS cp_mu_min real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS cp_mu_mean real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS cp_mu_median real;
+ALTER TABLE Beams ADD COLUMN IF NOT EXISTS cp_mu_max real;
+ALTER TABLE Plans ADD COLUMN IF NOT EXISTS complexity real;


### PR DESCRIPTION
* In the Regression tab, plotting any variable with min, median, mean, or max crashed on axis title update. Fixed.
* Min, mean, median and max of beam complexity, beam area, control point MU now calculated at time of import
    * These new values are available for time-series, correlation, and regression tabs in the main view
* Terminal now prints mrn of excluded plans due to non-numeral data used for correlation / regression
* Fixed bug causing crash at import due to some now missing SQL columns